### PR TITLE
Customizable fingerprint maximum fail attempts

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4184,6 +4184,12 @@ public final class Settings {
         public static final String STATUS_BAR_SHOW_TICKER = "status_bar_show_ticker";
 
         /**
+         * Maximum failed attempts for fingerprint input before showing warning
+         * @hide
+         */
+        public static final String FP_MAX_FAILED_ATTEMPTS = "fp_max_failed_attempts";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *

--- a/services/core/java/com/android/server/fingerprint/FingerprintService.java
+++ b/services/core/java/com/android/server/fingerprint/FingerprintService.java
@@ -27,6 +27,9 @@ import android.app.SynchronousUserSwitchObserver;
 import android.content.ComponentName;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.ContentResolver;
+import android.content.res.Configuration;
+import android.database.ContentObserver;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
@@ -44,6 +47,8 @@ import android.os.ServiceManager;
 import android.os.SystemClock;
 import android.os.UserHandle;
 import android.os.UserManager;
+import android.os.Handler;
+import android.provider.Settings;
 import android.util.Slog;
 
 import com.android.internal.logging.MetricsLogger;
@@ -103,7 +108,6 @@ public class FingerprintService extends SystemService implements IBinder.DeathRe
             new ArrayList<>();
     private final AppOpsManager mAppOps;
     private static final long FAIL_LOCKOUT_TIMEOUT_MS = 30*1000;
-    private static final int MAX_FAILED_ATTEMPTS = 5;
     private static final long CANCEL_TIMEOUT_LIMIT = 3000; // max wait for onCancel() from HAL,in ms
     private final String mKeyguardPackage;
     private int mCurrentUserId = UserHandle.USER_CURRENT;
@@ -119,6 +123,8 @@ public class FingerprintService extends SystemService implements IBinder.DeathRe
     private ClientMonitor mPendingClient;
     private long mCurrentAuthenticatorId;
     private PerformanceStats mPerformanceStats;
+
+    private int MAX_FAILED_ATTEMPTS;
 
     // Normal fingerprint authentications are tracked by mPerformanceMap.
     private HashMap<Integer, PerformanceStats> mPerformanceMap
@@ -189,6 +195,9 @@ public class FingerprintService extends SystemService implements IBinder.DeathRe
         mContext.registerReceiver(mLockoutReceiver, new IntentFilter(ACTION_LOCKOUT_RESET),
                 RESET_FINGERPRINT_LOCKOUT, null /* handler */);
         mUserManager = UserManager.get(mContext);
+        MAX_FAILED_ATTEMPTS = Settings.System.getIntForUser(
+                  mContext.getContentResolver(), Settings.System.FP_MAX_FAILED_ATTEMPTS,
+                  5, mCurrentUserId);
     }
 
     @Override


### PR DESCRIPTION
Add an option to customize maximum fingerprint failed attempts before
showing "Too many attempts". The change requires a reboot, we may need
to add a form of listener in FingerprintService for it to work without
rebooting.

This is the frameworks/base part of the commit, another commit is in
Settings.